### PR TITLE
Fix floor division erroring

### DIFF
--- a/syntaxes/lua.tmLanguage.json
+++ b/syntaxes/lua.tmLanguage.json
@@ -255,7 +255,7 @@
 		"operators": {
 			"patterns": [
 				{
-					"match": "(\\+|-(?!-)|/|\\*|%|\\^)",
+					"match": "(\\+|-(?!-)|/|//|\\*|%|\\^)",
 					"name": "keyword.operator.arithmetic.lua"
 				},
 				{


### PR DESCRIPTION
I think this should fix [floor division](https://luau.org/syntax#floor-division-) erroring, though I haven't checked what the `lua.tmLanguage.json` file does in the source code.